### PR TITLE
Make sure module initializer will wait until we confirm that the connection is reliable

### DIFF
--- a/src/nest-minio.module.ts
+++ b/src/nest-minio.module.ts
@@ -11,7 +11,7 @@ export class NestMinioModule extends ConfigurableModuleClass implements OnModule
 	constructor(readonly service: NestMinioService){
 		super();
 	}
-	onModuleInit() {
-		this.service.checkConnection()
+	async onModuleInit(): Promise<void> {
+		await this.service.checkConnection();
 	}
 }

--- a/src/nest-minio.service.ts
+++ b/src/nest-minio.service.ts
@@ -26,17 +26,13 @@ export class NestMinioService implements INestMinioService {
 		return this._minioConnection;
 	}
 
-	checkConnection() {
-		const { retries = 5, retryDelay = 1000 } = this.nestMinioOptions
+	async checkConnection(): Promise<void> {
+		const { retries = 5, retryDelay = 1000 } = this.nestMinioOptions;
 
-		lastValueFrom(from(this._minioConnection.listBuckets()).pipe(
+		await lastValueFrom(from(this._minioConnection.listBuckets()).pipe(
 			retry({ count: retries, delay: retryDelay })
-		))
-			.then(() => {
-				this.logger.log("Successfully connected to minio.")
-			})
-			.catch(error => {
-				this.logger.error(error)
-			})
+		));
+
+		this.logger.log("Successfully connected to minio.")
 	}
 }


### PR DESCRIPTION
OnModuleInit() could be awaitable. We should wait here otherwise the nestjs would start the server without waiting the minio module init. In some cases, this might cause race condition.